### PR TITLE
`.babelrc` should not be part of npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -35,3 +35,6 @@ jspm_packages
 
 # Optional REPL history
 .node_repl_history
+
+# Babel settings file
+.babelrc


### PR DESCRIPTION
It runs into issues with the react-native packager. It does not need to be published since the src is compiled through babel at build time.