### PR TITLE
Add babel configuration to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -20,6 +20,9 @@ coverage
 # Grunt intermediate storage (http://gruntjs.com/creating-plugins#storing-task-files)
 .grunt
 
+# babel configuration
+.babelrc
+
 # node-waf configuration
 .lock-wscript
 


### PR DESCRIPTION
`.babelrc` should be listed in `.npmignore`, I guess.

If not, it occurs a bug like below.

```
TransformError: <path>/node_modules/deline/build/deline.js:
Couldn't find preset "airbnb" relative to directory "<path>"
```